### PR TITLE
fix: rearrange code, fix logic of transfer

### DIFF
--- a/contracts/erc20/erc20.sol
+++ b/contracts/erc20/erc20.sol
@@ -7,6 +7,8 @@ pragma solidity ^0.8.19;
 /// @dev by default it mints all the tokens to the deployer address.
 contract ERC20Token {
     uint96 private _totalSupply;
+    string private _symbol;
+    string private _name;
 
     /// @dev event emmited when a token is transfered
     /// @param _from Address from whom token is transfered.
@@ -33,7 +35,9 @@ contract ERC20Token {
     mapping(address => uint96) public _balanceOf;
 
     /// @dev constructor currently consist of minting logic.
-    constructor() {
+    constructor(string memory tokenName, string memory tokenSymbol) {
+        _name = tokenName;
+        _symbol = tokenSymbol;
         _mint(msg.sender, 1000);
     }
 
@@ -47,14 +51,14 @@ contract ERC20Token {
 
     /// @dev Name of token
     /// @return name string
-    function name() external pure returns (string memory) {
-        return "DIVYANSHU COIN";
+    function name() external view returns (string memory) {
+        return _name;
     }
 
     /// @dev Symbol of token
     /// @return symbol string
-    function symbol() external pure returns (string memory) {
-        return "DIV";
+    function symbol() external view returns (string memory) {
+        return _symbol;
     }
 
     /// @dev Allowed decimal places

--- a/contracts/erc20/erc20.sol
+++ b/contracts/erc20/erc20.sol
@@ -88,7 +88,7 @@ contract ERC20Token {
         address _to,
         uint96 _value
     ) public returns (bool success) {
-        require(balanceOf(msg.sender) >= _value, "Insufficient Balance!");
+        require(_balanceOf[msg.sender] >= _value, "Insufficient Balance!");
         _balanceOf[_to] += _value;
         _balanceOf[msg.sender] -= _value;
 

--- a/contracts/erc20/erc20.sol
+++ b/contracts/erc20/erc20.sol
@@ -6,61 +6,61 @@ pragma solidity ^0.8.19;
 /// @notice creates contract for "DIV" token.
 /// @dev by default it mints all the tokens to the deployer address.
 contract ERC20Token {
-    string _name = "DIVYANSHU COIN";
-    string _symbol = "DIV";
-    uint96 _totalSupply = 10000 * _decimals;
-    uint8 _decimals = 6;
-
-    mapping(address => mapping(address => uint96)) _allowance;
-
-    mapping(address => uint96) public _balanceOf;
+    uint96 private _totalSupply;
 
     /// @dev event emmited when a token is transfered
     /// @param _from Address from whom token is transfered.
     /// @param _to Address to which token is transfered.
     /// @param _value Value of token to be transfered.
-    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Transfered(
+        address indexed _from,
+        address indexed _to,
+        uint256 _value
+    );
 
     /// @dev event emmited when someone approves else of their tokens
     /// @param _owner Owner of the tokens
     /// @param _spender Aproved address
     /// @param _value Value of token to be Approved!
-    event Approval(
+    event Approved(
         address indexed _owner,
         address indexed _spender,
         uint256 _value
     );
 
+    mapping(address => mapping(address => uint96)) private _allowance;
+
+    mapping(address => uint96) public _balanceOf;
+
     /// @dev constructor currently consist of minting logic.
     constructor() {
-        _mint(msg.sender, _totalSupply);
+        _mint(msg.sender, 1000);
     }
 
     /// @dev Mints the tokens to an address.
     /// @param _to address to mint tokens to
     /// @param _value ammount of tokens
-    function _mint(address _to, uint96 _value) private {
-        require(_totalSupply >= _value, "insufficient supply!");
+    function _mint(address _to, uint96 _value) public {
+        _totalSupply += _value;
         _balanceOf[_to] += _value;
-        _totalSupply -= _value;
     }
 
     /// @dev Name of token
     /// @return name string
-    function name() public view returns (string memory) {
-        return _name;
+    function name() external pure returns (string memory) {
+        return "DIVYANSHU COIN";
     }
 
     /// @dev Symbol of token
     /// @return symbol string
-    function symbol() public view returns (string memory) {
-        return _symbol;
+    function symbol() external pure returns (string memory) {
+        return "DIV";
     }
 
     /// @dev Allowed decimal places
     /// @return decimals uint8
-    function decimals() public view returns (uint8) {
-        return _decimals;
+    function decimals() external pure returns (uint8) {
+        return 6;
     }
 
     /// @dev Total Supply Available
@@ -84,11 +84,11 @@ contract ERC20Token {
         address _to,
         uint96 _value
     ) public returns (bool success) {
-        require(balanceOf(_to) >= _value, "Insufficient Balance!");
+        require(balanceOf(msg.sender) >= _value, "Insufficient Balance!");
         _balanceOf[_to] += _value;
         _balanceOf[msg.sender] -= _value;
 
-        emit Transfer(msg.sender, _to, _value);
+        emit Transfered(msg.sender, _to, _value);
         return true;
     }
 
@@ -102,11 +102,10 @@ contract ERC20Token {
         uint96 _value
     ) public returns (bool success) {
         require(
-            msg.sender == _from,
-            "sender address and from address must match!"
+            _value <= _allowance[_from][msg.sender],
+            "insufficient approved balance!"
         );
-        require(_value <= _allowance[_from][_to], "insufficient approval");
-        _allowance[_from][_to] -= _value;
+        _allowance[_from][msg.sender] -= _value;
         _balanceOf[_from] -= _value;
         _balanceOf[_to] += _value;
         return true;
@@ -121,7 +120,7 @@ contract ERC20Token {
         uint96 _value
     ) public returns (bool success) {
         _allowance[msg.sender][_spender] = _value;
-        emit Approval(msg.sender, _spender, _value);
+        emit Approved(msg.sender, _spender, _value);
         return true;
     }
 


### PR DESCRIPTION
### Changes - 
- rearrange code according to solidity standards
- fix logic of `transfer` & `transferFrom`
- even names in past tense
- remove unnecessary state variables
- make contract generic for any token name/symbol